### PR TITLE
Recompress slim layers to gzip before pushing

### DIFF
--- a/.github/workflows/postgresql.yml
+++ b/.github/workflows/postgresql.yml
@@ -240,8 +240,16 @@ jobs:
           regctl image import "ocidir:///tmp/slim-oci:slim" /tmp/slim.tar
           rm /tmp/slim.tar
 
+          # docker save writes uncompressed layer tarballs (.tar, not .tar.gzip).
+          # Pushed as-is the slim image lands in the registry larger than the
+          # un-slimmed base. Recompress layers to gzip in place so the registry
+          # blob sizes reflect the slim toolkit's actual size win.
+          regctl image mod "ocidir:///tmp/slim-oci:slim" \
+            --layer-compress gzip --replace
+
           # Compute the manifest digest locally so we can address the registry push
-          # by digest URL — no tag is created on Docker Hub.
+          # by digest URL — no tag is created on Docker Hub. Must happen AFTER the
+          # mod step: recompressing layers changes layer digests → manifest digest.
           DIGEST="$(regctl manifest digest "ocidir:///tmp/slim-oci:slim")"
           echo "Slim digest (${{ matrix.arch }}): ${DIGEST}"
 


### PR DESCRIPTION
## Summary

Follow-up to #32. After it landed, the slim variant on Docker Hub was *larger* than the un-slimmed base (`develop-slim` 2.56 GB amd64 / 2.48 GB arm64 vs `develop` 1.91 GB / 1.97 GB).

Inspecting the manifests showed why: the slim image had a single layer with media type `application/vnd.oci.image.layer.v1.tar` — uncompressed — while `develop`'s layers were `...tar.gzip`. `docker save` always writes uncompressed layer tarballs, and the import → copy pipeline shipped them to the registry as-is, throwing away the slim toolkit's actual size win.

Insert a `regctl image mod --layer-compress gzip --replace` step between import and digest computation. It rewrites layer blobs to `application/vnd.oci.image.layer.v1.tar+gzip` in place. The digest is captured *after* the mod, since recompressing layers changes layer digests → manifest digest.

Verified locally that `image mod --layer-compress gzip` does what's advertised: round-tripping alpine through `--layer-compress none` (8.0 MB uncompressed) → `--layer-compress gzip` (3.6 MB) recovers the gzipped form, and the layer media type updates correctly.

`regctl image mod` is tagged EXPERIMENTAL by upstream — meaning the flag interface may evolve in future versions, not that the command is unstable. Since `release: v0.11.3` is pinned, the surface is locked.